### PR TITLE
Snapshot support, single network, no mocker dependency

### DIFF
--- a/d3-demo.html
+++ b/d3-demo.html
@@ -7,6 +7,7 @@
 
     <script src="js/lib/jquery-2.2.4.min.js"></script>
     <script src="js/lib/d3.v4.min.js"></script>    
+    <script src="js/clickhandlers.js"></script>
     <script src="js/timemachine.js"></script>
     <script src="js/visuals.js"></script>
     <script src="js/network.js"></script>

--- a/d3-demo.html
+++ b/d3-demo.html
@@ -31,7 +31,7 @@
         </div>
         -->
         <div class="title">
-          p2p Network Connectivity Graph
+          P2P Network Connectivity Graph
         </div>
         <!-- Currently disabled
         <div class="menu" onclick="showMenu()">
@@ -49,11 +49,11 @@
       <div id="sidebar" class=sidebar>
         <div class="controls">
           <i id="power" class="fa fa-power-off power-off" aria-hidden="true"></i>
-          <i id="play" class="invisible fa fa-play-circle" aria-hidden="true"></i>
-          <!--
-          <i id="pause" class="invisible fa fa-pause" aria-hidden="true"></i>
-          -->
+          <i id="start" class="invisible fa fa-play" aria-hidden="true"></i>
           <i id="stop" class="invisible fa fa-stop" aria-hidden="true"></i>
+          <i id="upload" class="invisible fa fa-upload" aria-hidden="true"></i>
+          <i id="snapshot" class="invisible fa fa-camera-retro" aria-hidden="true"></i>
+          <i id="play" class="invisible fa fa-play-circle" aria-hidden="true"></i>
           <i id="refresh" class="invisible fa fa-fast-backward" aria-hidden="true"></i>
           <div class="display">
             <div class="elapsed">Time elapsed: <span id="time-elapsed">00:00:00</span></div>

--- a/js/clickhandlers.js
+++ b/js/clickhandlers.js
@@ -1,0 +1,90 @@
+$(document).ready(function() {
+  
+  //click handlers
+  $('#power').on('click',function(){ 
+    if ($(this).hasClass("power-off")) {
+      if ($("#timemachine").is(":visible")) {
+        pauseReplay();
+        clearViz();
+      } 
+      initializeServer(networkname); 
+    } else {
+      stopNetwork(); 
+    }
+  });
+
+  $('#stop').on('click',function(){ 
+    stopNetwork(); 
+    $("#status-messages").hide();
+  });
+
+  $('#play').on('click',function(){ 
+    if ($(this).hasClass("fa-play-circle")) {
+      continueReplay(); 
+      $(this).removeClass("fa-play-circle");
+      $(this).addClass("fa-pause");
+    } else {
+      $(this).addClass("fa-play-circle");
+      $(this).removeClass("fa-pause");
+      pauseReplay(); 
+    }
+  });
+
+  $("#start").click(function() {
+    startSim();
+  });
+
+  $("#pause").click(function() {
+    pauseNetwork();
+  });
+
+  $("#refresh").click(function() {
+    replayViz();
+  });
+
+  $("#snapshot").click(function() {
+    takeSnapshot();
+  });
+
+  $("#upload").click(function() {
+    uploadSnapshot();
+  });
+
+  $("#rec-messages").change(function() {
+    if(this.checked) {
+      rec_messages = true;
+    } else {
+      rec_messages = false;
+    }
+  });
+
+  $('.menuitem').on('click',function(){ 
+    switch ($(this).attr("id")) {
+      case "selectmocker": 
+              selectMocker();
+              $("menu").hide("slow");
+              break;
+      default: 
+              selectMocker();
+              break;
+    }
+  });
+
+  $("#showlogs").change(function() {
+    if ($('#showlogs').is(":checked") ) {
+      $('#output-window').show("slow"); 
+    } else {
+      $('#output-window').hide("slow"); 
+    }
+  });
+
+  $('#output-window').on('click',function(){ 
+    $('#output-window').toggleClass("closepane"); 
+  });
+
+  $('#selected-simulation').text(selectedSim);
+
+  //pollServer();
+  setVisualisationFrame();
+});
+

--- a/js/clickhandlers.js
+++ b/js/clickhandlers.js
@@ -7,7 +7,7 @@ $(document).ready(function() {
         pauseReplay();
         clearViz();
       } 
-      initializeServer(networkname); 
+      initializeServer(); 
     } else {
       stopNetwork(); 
     }
@@ -32,10 +32,6 @@ $(document).ready(function() {
 
   $("#start").click(function() {
     startSim();
-  });
-
-  $("#pause").click(function() {
-    pauseNetwork();
   });
 
   $("#refresh").click(function() {

--- a/js/timemachine.js
+++ b/js/timemachine.js
@@ -105,6 +105,7 @@ function setupTimemachine() {
   Timemachine.skipCollectionSetup = true; 
   Timemachine.sidebar = visualisation.sidebar; 
   Timemachine.sidebar.visualisation = self; 
+  TimemachineIndex = 0;
   /*
   Timemachine.graphNodes = $.extend(true, [], visualisation.graphNodes);
   Timemachine.graphLinks = $.extend(true, [], visualisation.graphLinks);
@@ -138,7 +139,7 @@ function setupTimemachine() {
   $("#network-visualisation").hide();
 }
 
-function continueReplay () {
+function continueReplay() {
   TimemachineReplay();
 }
 
@@ -154,6 +155,7 @@ TimemachineReplay = function() {
     Timemachine.graphLinks = [];
     Timemachine.nodesById  = {};
     Timemachine.connsById  = {};
+    $("#timemachine").val(0);
   }
   replayInterval = setInterval(function() {TimemachineStep(TimemachineIndex)}, replaySpeed);
 }
@@ -176,20 +178,10 @@ TimemachineStep = function(idx) {
 TimemachineForward = function(idx) {
   var evt         = eventHistory[idx];
   var time        = evt.timestamp;
-  var content     = evt.content;
+  var content     = $.extend(true, {}, evt.content);
   $("#time-elapsed").text(time);
-  var newNodes    = [];
-  var removeNodes = [];
-  var newLinks    = [];
-  var removeLinks = [];
-  var triggerMsgs = [];
 
-  removeNodes = getGraphNodes($(content.remove));
-  removeLinks = getGraphLinks($(content.remove));
-  newNodes = getGraphNodes($(content.add));
-  newLinks = getGraphLinks($(content.add));
-
-  Timemachine.updateVisualisation(newNodes,newLinks,removeNodes,removeLinks,triggerMsgs); 
+  Timemachine.updateVisualisation(content); 
   //Timemachine.sidebar.updateSidebarCounts(newNodes, newLinks, removeNodes, removeLinks);
 }
 
@@ -199,17 +191,7 @@ TimemachineBackward = function(idx) {
   var time        = evt.timestamp;
   var content     = evt.content;
   $("#time-elapsed").text(time);
-  var newNodes    = [];
-  var removeNodes = [];
-  var newLinks    = [];
-  var removeLinks = [];
-  var triggerMsgs = [];
 
-  removeNodes = getGraphNodes($(content.add));
-  removeLinks = getGraphLinks($(content.add));
-  newNodes = getGraphNodes($(content.remove));
-  newLinks = getGraphLinks($(content.remove));
-
-  Timemachine.updateVisualisation(newNodes,newLinks,removeNodes,removeLinks,triggerMsgs); 
-  Timemachine.sidebar.updateSidebarCounts(newNodes, newLinks, removeNodes, removeLinks);
+  Timemachine.updateVisualisation(content); 
+  //Timemachine.sidebar.updateSidebarCounts(newNodes, newLinks, removeNodes, removeLinks);
 }

--- a/js/visuals.js
+++ b/js/visuals.js
@@ -534,29 +534,7 @@ class P2Pd3 {
     this.linksChanged = true;
   }
 
-  hideNodesLinks(id) {
-    var linksToHide = [];
-    var connList = this.connsById;
-    Object.keys(connList).forEach(function(key,index) {
-      if (nodeShortLabel(connList[key].source) == id ||
-          nodeShortLabel(connList[key].target) == id ) {
-        linksToHide.push({id: key});
-        eventHistory.push({timestamp:$("#time-elapsed").text(), content: {add:[], remove:[{id: key}]} });
-        //uplinks -= 1;
-        //console.log("REMOVE connection, id:" + key);
-        //delete connList[key];
-      }
-    });
-    //$("#edges-up-count").text(uplinks);
-    this.removeLinks(linksToHide);
-    //delete this.nodesById[id];
-  } 
-
   updateKadTable(nodeId) {
-  //$('#node-kademlia-table').addClass("stale");
-  //if (selectionActive) {
-  //  $('#kad-hint').removeClass("invisible");
-  //}
     this.sidebar.getNodeInfo(nodeId);
     console.log("Kad table of selected Node updated");
   }

--- a/js/visuals.js
+++ b/js/visuals.js
@@ -32,7 +32,7 @@ class P2Pd3Sidebar {
     var classThis = this;
   
     $.ajax({
-      url: BACKEND_URL + "/networks/"  + networkname + "/nodes/" + nodeId,
+      url: BACKEND_URL + "/nodes/" + nodeId,
       type: "GET",
       dataType: "json"
       }).then(
@@ -171,7 +171,7 @@ function killLink() {
 
 function killNode() {
   var node = $('#full-node-id').val();
-  $.post(BACKEND_URL + "/networks/" + networkname + "/nodes/" + node + "/stop").then(
+  $.post(BACKEND_URL + "/nodes/" + node + "/stop").then(
     function(d) {
       console.log("Node successfully stopped");
       $('#kad-hint').addClass("invisible");
@@ -192,7 +192,7 @@ function finalizeConnectTo() {
   selectingTarget = false;
   var target = $("#target-id").val();
   var source = $("#full-node-id").val();
-  $.post(BACKEND_URL + "/networks/" + networkname + "/nodes/" + source+ "/conn/" + target).then(
+  $.post(BACKEND_URL + "/nodes/" + source+ "/conn/" + target).then(
     function(d) {
       console.log("Node successfully connected");
     },
@@ -206,7 +206,7 @@ function disconnectLink(id) {
   var conn = visualisation.connsById[id];
   //$.ajax(options);
   $.ajax({
-    url: BACKEND_URL + "/networks/" + networkname + "/nodes/" + conn.source+ "/conn/" + conn.target,
+    url: BACKEND_URL + "/nodes/" + conn.source+ "/conn/" + conn.target,
     type: "DELETE",
     data: {},
     contentType:'application/json',


### PR DESCRIPTION
This PR adds snapshot support: A snapshot JSON file can be saved to the local file system. 
Also, a JSON snapshot file can be uploaded to start a network with it.

Also synced to the new backend single network API.

Removed mocker dependency (if no mocker is available, it will show anything existing transmitted through the event stream).

Lean refactoring of visualization objects.